### PR TITLE
Clean up if adapter fails to open

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -708,6 +708,16 @@ void Adapter::Open(uv_work_t *req)
     {
         std::cerr << std::endl << "Failed to open the nRF5 BLE driver." << std::endl;
         baton->result = error_code;
+
+        // Delete the adapter layer and all layers below
+        sd_rpc_adapter_delete(adapter);
+
+        // Free memory malloc'ed by the sd_rpc_create* functions
+        free(uart);
+        free(h5);
+        free(serialization);
+        free(adapter);
+
         return;
     }
 


### PR DESCRIPTION
Ref. #90.

The `sd_rpc_adapter_delete()` function deletes the adapter layer (`AdapterInternal` object). The `AdapterInternal` destructor then deletes the `SerializationTransport`, and this cascades all the way down to `H5Transport` and `UartBoost`.

To me it looks like clean up needs to be done when the adapter is closed as well.